### PR TITLE
Respect debug mode on HTTP Exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -115,14 +115,12 @@ class Handler implements ExceptionHandlerContract {
 	{
 		$status = $e->getStatusCode();
 
-		if (view()->exists("errors.{$status}"))
+		if(($debug = config('app.debug')) or !view()->exists("errors.{$status}"))
 		{
-			return response()->view("errors.{$status}", [], $status);
+			return (new SymfonyDisplayer($debug))->createResponse($e);
 		}
-		else
-		{
-			return (new SymfonyDisplayer(config('app.debug')))->createResponse($e);
-		}
+
+		return response()->view("errors.{$status}", [], $status);
 	}
 
 	/**


### PR DESCRIPTION
In case of an HTTP exception if there are custom error pages present, these custom error pages are always shown even if debug is enabled. This means that for local development, the developer has no access to the debugging page but only views the application error page. These error pages should only be shown if debug is disabled.

This proposes a change in logic:
- if debug mode is TRUE, always display the debugging page.
- if debug mode is FALSE, first try to display the custom errorpage if it exists. Else resort to the default Symfony error rendering.